### PR TITLE
Fixes issue #7 (sequence number issue)

### DIFF
--- a/src/kadmium-sacn-core/SACNPacket.cs
+++ b/src/kadmium-sacn-core/SACNPacket.cs
@@ -281,7 +281,7 @@ namespace kadmium_sacn_core
             using (var stream = new MemoryStream(Length))
             using (var buffer = new BigEndianBinaryWriter(stream))
             {
-                UInt16 flagsAndDMPLength = (UInt16)(SACNPacket.FLAGS | Length);
+                UInt16 flagsAndDMPLength = (UInt16)(SACNPacket.FLAGS | (UInt16)Length);
 
                 buffer.Write(flagsAndDMPLength);
                 buffer.Write(DMP_VECTOR);

--- a/src/kadmium-sacn-core/kadmium-sacn-core.csproj
+++ b/src/kadmium-sacn-core/kadmium-sacn-core.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>0.0.10</Version>
+    <Version>0.0.11</Version>
     <Authors>Jesse Higginson;Hakan Lindestaf</Authors>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Title>Kadmium-sACN-Core</Title>
@@ -18,7 +18,7 @@
     <Copyright>Copyright 2016-2017 Jesse Higginson</Copyright>
     <PackageTags>sACN;DMX</PackageTags>
     <PackageReleaseNotes>Parsing fixes, added a listener</PackageReleaseNotes>
-    <AssemblyVersion>0.0.10.0</AssemblyVersion>
+    <AssemblyVersion>0.0.11.0</AssemblyVersion>
     <FileVersion>0.0.10.0</FileVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
When using more than one universe per sender (supported) the generated sequence numbers are invalid according to the E1.31 specification. This commit should fix that (plus another commit for a warning in VS)